### PR TITLE
Use stop instead of returning a string

### DIFF
--- a/R/allocate.R
+++ b/R/allocate.R
@@ -98,7 +98,7 @@ allocate <- function(centroids, hex_grid, sf_id = names(centroids)[1], hex_size,
           width <- width + 5
         }
         else {
-          return("This hexmap could not be completed. Try expanding the buffer distance.")
+          stop("This hexmap could not be completed. Try expanding the buffer distance.")
         }
         message(paste("Issue at ", pull(centroid[, 1]), ": Cannot expand further, trying a wider angle of ", width, " degrees."))
       }


### PR DESCRIPTION
I reckon it's more helpful for debugging to slam on the brakes at this point rather than return a different type of variable.